### PR TITLE
Import user attributes

### DIFF
--- a/examples/ImportUserAttributes/ImportUserAttributes_suite_test.go
+++ b/examples/ImportUserAttributes/ImportUserAttributes_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestImportUserAttributes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ImportUserAttributes Suite")
+}

--- a/examples/ImportUserAttributes/ImportUserAttributes_test.go
+++ b/examples/ImportUserAttributes/ImportUserAttributes_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"github.com/TheJumpCloud/jcapi"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ImportUserAttributes", func() {
+
+	Describe("Building attributes struct", func() {
+
+		var attributeNames []string
+		var user jcapi.JCUser
+		var userRecord []string
+		var attributes userAttributes
+
+		buildAttributeMap := func(attributes userAttributes) map[string]string {
+			attributeMap := make(map[string]string)
+			for _, attribute := range attributes.Attributes {
+				attributeMap[attribute.Name] = attribute.Value
+			}
+			return attributeMap
+		}
+
+		addAttributeToUser := func(user *jcapi.JCUser, name string, value string) {
+			user.Attributes = append(user.Attributes, jcapi.JCUserAttribute{Name: name, Value: value})
+		}
+
+		BeforeEach(func() {
+			attributeNames = []string{"Attr1", "Attr2"}
+			userRecord = []string{"email", "Value1", "Value2"}
+			user = jcapi.JCUser{}
+		})
+
+		Context("With no existing attributes", func() {
+
+			BeforeEach(func() {
+				attributes = buildAttributes(user, userRecord, attributeNames)
+			})
+			It("should have only new attributes", func() {
+				Expect(len(attributes.Attributes)).To(Equal(2))
+			})
+			It("should contain the correct attributes", func() {
+				attributeMap := buildAttributeMap(attributes)
+				Expect(attributeMap["Attr1"]).To(Equal("Value1"))
+				Expect(attributeMap["Attr2"]).To(Equal("Value2"))
+			})
+		})
+
+		Context("With existing attributes not in user record", func() {
+			BeforeEach(func() {
+				// add two non-matching attributes
+				addAttributeToUser(&user, "ExistingAttr1", "ExistingValue1")
+				addAttributeToUser(&user, "ExistingAttr2", "ExistingValue2")
+				attributes = buildAttributes(user, userRecord, attributeNames)
+			})
+			It("should have new and existing attributes", func() {
+				Expect(len(attributes.Attributes)).To(Equal(4))
+			})
+			It("should contain the correct attributes", func() {
+				attributeMap := buildAttributeMap(attributes)
+				Expect(attributeMap["Attr1"]).To(Equal("Value1"))
+				Expect(attributeMap["Attr2"]).To(Equal("Value2"))
+				Expect(attributeMap["ExistingAttr1"]).To(Equal("ExistingValue1"))
+				Expect(attributeMap["ExistingAttr2"]).To(Equal("ExistingValue2"))
+			})
+		})
+
+		Context("With existing attributes not in user record", func() {
+			BeforeEach(func() {
+				// add one matching and one non-matching attribute
+				addAttributeToUser(&user, "ExistingAttr1", "ExistingValue1")
+				addAttributeToUser(&user, "Attr2", "ExistingValue2")
+				attributes = buildAttributes(user, userRecord, attributeNames)
+			})
+			It("should have replaced one attribute", func() {
+				Expect(len(attributes.Attributes)).To(Equal(3))
+			})
+			It("should contain the correct attributes", func() {
+				attributeMap := buildAttributeMap(attributes)
+				Expect(attributeMap["Attr1"]).To(Equal("Value1"))
+				Expect(attributeMap["Attr2"]).To(Equal("Value2"))
+				Expect(attributeMap["ExistingAttr1"]).To(Equal("ExistingValue1"))
+			})
+		})
+
+	})
+
+	Describe("Validating attribute names", func() {
+
+		var attributeNames []string
+		var err error
+
+		Context("With valid attributes", func() {
+			BeforeEach(func() {
+				attributeNames = []string{"ValidAttribute1", "12345678901234567890123456789012"}
+				err = validateAttributeNames(attributeNames)
+			})
+			It("should not error", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("With an empty attribute", func() {
+			BeforeEach(func() {
+				attributeNames = []string{""}
+				err = validateAttributeNames(attributeNames)
+			})
+			It("should error", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+		Context("With an attribute containing spaces", func() {
+			BeforeEach(func() {
+				attributeNames = []string{"Attri Bute"}
+				err = validateAttributeNames(attributeNames)
+			})
+			It("should error", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+		Context("With an attribute containing non-alphanumerics", func() {
+			BeforeEach(func() {
+				attributeNames = []string{"Attri_Bute"}
+				err = validateAttributeNames(attributeNames)
+			})
+			It("should error", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+		Context("With an attribute that exceed 32 characters", func() {
+			BeforeEach(func() {
+				attributeNames = []string{"123456789012345678901234567890123"}
+				err = validateAttributeNames(attributeNames)
+			})
+			It("should error", func() {
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+	})
+
+})

--- a/examples/ImportUserAttributes/README.md
+++ b/examples/ImportUserAttributes/README.md
@@ -1,0 +1,3 @@
+## User Attribute Importer
+
+#### Go Tools

--- a/examples/ImportUserAttributes/README.md
+++ b/examples/ImportUserAttributes/README.md
@@ -1,3 +1,112 @@
 ## User Attribute Importer
 
-#### Go Tools
+This tool allows you as a system administrator to add custom attributes to a systemuser. The attributes are defined in a file and mapped
+to users through the user's email. Existing attributes that are not defined in the file will be retained. However, existing attributes that 
+exist in the file will be overwritten.
+
+
+### To Install
+
+##### I do not have the Go toolchain installed
+> Most users will want to follow these instructions
+
+1. Go to the "Releases" tab of this github project
+	- https://github.com/TheJumpCloud/jcapi/releases
+2. We have provided `.zip` files for most operating systems
+	- Note that macOS users will want to use the `darwin` binaries
+3. Download the zip file of your choice 
+	- We always recommend downloading from the latest release if possible
+	- Most Windows users will want the `386` zip
+4. Extract the files from the zip
+	- Right click on the zip file and click `Extract All` on Windows
+	- Double click on the zip file on macOS/Linux
+5. `importUserAttributes_myos_myarch` is the relevant binary
+	- Some may find this is an unwieldy name to type every time. Feel free to rename to your liking, in fact if this is a tool you plan on running 
+    frequently we encourage this for ease of use.
+
+> If you'd like to be able to call this binary from an arbitrary directory you can move it to `/usr/local/bin` on Linux and macOS
+>> On macOS the keyboard shortcut `⌘ + Shift + G` with an open Finder window will allow you to directly type in the directory you'd like to access. 
+To move the binary to `/usr/local/bin` with Finder simply use that shortcut and copy/paste `/usr/local/bin` into the dialog box. You can now drag and 
+drop the binary onto the Finder window to easily make it accessible without having to navigate to a specific folder to run it. If you do this we also 
+recommend renaming the binary before moving it to a more memorable name.
+
+##### I have the Go toolchain installed
+> If you don't know what "Go" or "Golang" is we have provided pre-made binaries for your convenience. Installation instructions for these 
+binaries is provided in the previous section
+
+1. Clone the `jcapi` repository (it doesn't matter where)
+	- `git clone https://github.com/TheJumpCloud/jcapi`
+2. Navigate to the `jcapi/examples/importUserAttributes` directory
+	- `cd jcapi/examples/importUserAttributes`
+3. Run go install
+	- `go install .`
+
+This will install a binary called `importUserAttributes` to your `$GOBIN`
+
+> If you'd like to be able to call this binary from an arbitrary directory make sure your `$GOBIN` is in your `$PATH` (linux) or `%PATH%` (windows)
+
+### To Run
+
+To run this tool you will need to use the command line. On Windows you can use PowerShell and on OSX you can use Terminal. 
+
+> While running this tool requires no previous experience with either of those programs some might feel wary or nervous working with a tool 
+they don't understand. The following instructions in this section should provide you with all you need to get up and running, but if you would 
+like to learn about the how and why of the command line we highly recommend the excellent (and free!) 
+[Command Line Crash Course by Zed Shaw](http://cli.learncodethehardway.org/). Zed even provides a direct email hotline for users that get stuck. 
+If problems persist, or you are unsure of where to begin contact JumpCloud support for assistance running this tool.
+
+The input file must be in comma-separated value format as follows:
+- First row (header) defines all attributes to be imported starting in the second column (first column of header row is ignored)
+- The values in the header row will become the attribute name 
+- Attribute names cannot exceed 32 characters, cannot contain spaces and must be alphanumeric
+- Subsequent rows define attribute values for individual users 
+- The first column of the user rows must contain the user's email 
+- The remaining columns contain the attribute values for the user
+
+Input File Example:
+```
+email,Location,Role
+john.smith@example.org,Boulder,Manager
+jane.doe@example.org,Denver,Developer
+```
+This tool takes two required arguments and two optional arguments:
+- `api-key` is your JumpCloud API key (required)
+- `input` is the path to the input file (required)
+- `output` is the path to the output results file (optional, defaults to results.log in the current directory)
+- `url` is the JumpCloud API URL (optional)
+
+For example:
+
+`./importUserAttributes -api-key=82105124f2979e28273d4e8dd32b2355c5012837 -input=userattributes.csv -output=test_results.log`
+
+> If you have renamed your binary simply replace `importUserAttributes` with the new name
+
+> If you installed the binary with the Go toolchain and your `$GOBIN` is in your `$PATH` or `%PATH%`, or if you moved the binary to `/usr/local/bin` you 
+can run the above command at any time on your command line excluding the "./"
+
+##### Windows Instructions
+1. Open `PowerShell`
+2. Using the `cd` (stands for "Change Directory") command navigate to where you downloaded your binaries
+	- For example, if we downloaded and unzipped the binaries in our `Download` folder we just have to run: `cd Downloads\JumpCloudAPI_Examples_windows_386`. 
+    If we downloaded to our desktop the command will probably look something like: `cd Desktop\JumpCloudAPI_Examples_windows_386`
+	- If you used the Go install instructions and your `$GOBIN` is in your `%PATH%` you can skip step 2 and go right to 3
+3. Grab your API key from the JumpCloud Admin console
+	- Click on your email on the top right hand corner to access the API Settings
+4. Run the command
+	- `./importUserAttributes.exe -api-key=YOUR_API_KEY_GOES_HERE -input=INPUT_FILE_GOES_HERE`
+
+> To run a command simply type it into the PowerShell window and hit `Enter` or `Return` when finished 
+
+##### macOS/Linux Instructions
+1. Open `Terminal` (this can be found in `Applications/Utilities`)
+2. Using the `cd` (stands for "Change Directory") command navigate to where you downloaded your binaries
+	- For example, if we downloaded and unzipped the binaries in our `Download` folder we just have to run: `cd Downloads/JumpCloudAPI_Examples_darwin_amd64`. 
+    If we downloaded to our desktop the command will probably look something like: `cd Desktop/JumpCloudAPI_Examples_darwin_amd64`
+	- If you used the Go install instructions and your `$GOBIN` is in your `$PATH`, or if you manually moved the binary to `/usr/local/bin` you can skip step 2 
+    and go right to 3
+3. Grab your API key from the JumpCloud Admin console
+	- Click on your email on the top right hand corner to access the API Settings
+4. Run the command
+	- `./importUserAttributes.exe -api-key=YOUR_API_KEY_GOES_HERE -input=INPUT_FILE_GOES_HERE`
+
+> To run a command simply type it into the Terminal window and hit `Enter` or `Return` when finished 

--- a/examples/ImportUserAttributes/importUserAttributes.go
+++ b/examples/ImportUserAttributes/importUserAttributes.go
@@ -14,8 +14,10 @@ import (
 	"github.com/TheJumpCloud/jcapi"
 )
 
-const defaultURLBase string = "https://console.jumpcloud.com/api"
-const defaultOutFile string = "results.log"
+const (
+	defaultURLBase = "https://console.jumpcloud.com/api"
+	defaultOutFile = "results.log"
+)
 
 type userAttributes struct {
 	Attributes []jcapi.JCUserAttribute `json:"attributes"`
@@ -25,8 +27,7 @@ func getUserByEmail(jc jcapi.JCAPI, email string) ([]jcapi.JCUser, error) {
 	jcUsers, jcErr := jc.GetSystemUserByEmail(email, false)
 
 	if jcErr != nil {
-		err := fmt.Errorf("Error retrieving user for email %s: %s", email, jcErr.Error())
-		return jcUsers, err
+		return nil, fmt.Errorf("Error retrieving user for email %s: %s", email, jcErr)
 	}
 	return jcUsers, nil
 }

--- a/examples/ImportUserAttributes/importUserAttributes.go
+++ b/examples/ImportUserAttributes/importUserAttributes.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/TheJumpCloud/jcapi"
+)
+
+// DefaultURLBase is the production api endpoint.
+const DefaultURLBase string = "https://console.jumpcloud.com/api"
+
+type userAttribute struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type userAttributes struct {
+	Attributes []userAttribute `json:"attributes"`
+}
+
+func getUserByEmail(jc jcapi.JCAPI, email string) ([]jcapi.JCUser, error) {
+	jcUsers, jcErr := jc.GetSystemUserByEmail(email, false)
+
+	if jcErr != nil {
+		err := fmt.Errorf("Error retrieving user for email %s: %s", email, jcErr.Error())
+		return jcUsers, err
+	}
+	return jcUsers, nil
+}
+
+func buildAttributes(userRecord []string, attributeNames []string) userAttributes {
+
+	recordLen := len(userRecord)
+	attributeArray := make([]userAttribute, len(attributeNames))
+
+	for i, attributeName := range attributeNames {
+		attributeArray[i] = userAttribute{Name: attributeName}
+		// acount for empty attributes at end of record
+		if recordLen > (i + 1) {
+			attributeArray[i].Value = userRecord[i+1]
+		}
+	}
+
+	return userAttributes{attributeArray}
+}
+
+func importUserAttributes(jc jcapi.JCAPI, user jcapi.JCUser, attributes userAttributes) error {
+
+	b, err := json.Marshal(attributes)
+	if err != nil {
+		return fmt.Errorf("Error converting attributes to JSON: %s", err.Error())
+	}
+
+	url := "/systemusers/" + user.Id
+	_, jcErr := jc.Put(url, b)
+	if jcErr != nil {
+		return fmt.Errorf("Error setting attribute(s) on user %s: %s", user.Email, jcErr.Error())
+	}
+	return nil
+
+}
+
+func main() {
+
+	// input parameters
+	apiKey := flag.String("api-key", "", "Your JumpCloud Administrator API Key")
+	inputFilePath := flag.String("inputFile", "", "CSV file containing user identifier and attributes")
+	baseURL := flag.String("url", DefaultURLBase, "Base API Url override")
+
+	flag.Parse()
+
+	if *apiKey == "" || *inputFilePath == "" {
+		flag.Usage()
+		return
+	}
+
+	// Attach to JumpCloud API
+	jc := jcapi.NewJCAPI(*apiKey, *baseURL)
+
+	// Setup access to input/output files
+	inputFile, err := os.Open(*inputFilePath)
+	if err != nil {
+		fmt.Printf("Error opening input file %s: %s\n", *inputFilePath, err)
+		return
+	}
+	defer inputFile.Close()
+
+	// Read input file and process users one at a time
+	reader := csv.NewReader(inputFile)
+	reader.FieldsPerRecord = -1 // indicates records have optional fields
+
+	// Read header row (userIdentifier, attributeName(s)...)
+	headerRecord, err := reader.Read()
+	if err != nil {
+		fmt.Printf("Error reading header row: %s\n", err)
+		return
+	}
+
+	if len(headerRecord) < 2 {
+		fmt.Printf("Invalid header row: File must contain at least 2 columns\n")
+		return
+	}
+	attributeNames := headerRecord[1:]
+	// TODO: validate attribute names?
+
+	// Read each row (user identifier + attribute values)
+	userCount := 0
+	importedUserCount := 0
+	var unknownUsers []string
+	var errorsByUser = make(map[string]error)
+
+	for {
+
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+
+		userCount++
+		if err != nil {
+			fmt.Printf("Error reading record on line %d: %s\n", userCount+1, err)
+			return
+		}
+
+		// Fetch user by email
+		email := record[0]
+		users, err := getUserByEmail(jc, email)
+		if err != nil {
+			errorsByUser[email] = err
+			continue
+		}
+
+		if len(users) == 0 {
+			unknownUsers = append(unknownUsers, email)
+			continue
+		}
+
+		user := users[0]
+		attributes := buildAttributes(record, attributeNames)
+		err = importUserAttributes(jc, user, attributes)
+		if err != nil {
+			errorsByUser[email] = err
+		} else {
+			importedUserCount++
+		}
+
+	}
+
+	fmt.Println("\nImport complete:")
+	fmt.Printf("  %d users processed\n", userCount)
+	fmt.Printf("  %d users imported\n", importedUserCount)
+	fmt.Printf("  %d users not found\n", len(unknownUsers))
+	fmt.Printf("  %d errors processing users\n", len(errorsByUser))
+
+	if len(unknownUsers) > 0 {
+		fmt.Println("\nUnknown Users:")
+		for _, userEmail := range unknownUsers {
+			fmt.Printf("  %s\n", userEmail)
+		}
+	}
+
+	if len(errorsByUser) > 0 {
+		fmt.Println("\nUser Errors:")
+		for email, err := range errorsByUser {
+			fmt.Printf("  %s: %s\n", email, err.Error())
+		}
+	}
+	fmt.Println("")
+
+	return
+
+}

--- a/examples/ImportUserAttributes/importUserAttributes.go
+++ b/examples/ImportUserAttributes/importUserAttributes.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/TheJumpCloud/jcapi"
 )
@@ -200,6 +201,12 @@ func main() {
 		if err != nil {
 			fmt.Printf("Error reading record on line %d: %s\n", userCount+1, err)
 			return
+		}
+
+		// sleep every 50 users to not overload API server
+		if userCount%50 == 0 {
+			fmt.Printf("%d users processed. Sleeping 5 seconds...\n", userCount)
+			time.Sleep(time.Second * 5)
 		}
 
 		// Fetch user by email

--- a/examples/ImportUserAttributes/importUserAttributes.go
+++ b/examples/ImportUserAttributes/importUserAttributes.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 
+	"regexp"
+
 	"github.com/TheJumpCloud/jcapi"
 )
 
@@ -65,6 +67,28 @@ func importUserAttributes(jc jcapi.JCAPI, user jcapi.JCUser, attributes userAttr
 
 }
 
+func validateAttributeNames(attributeNames []string) error {
+
+	// 0 < length < 32
+	// Alphanumeric, no spaces
+	isAlphaNumeric := regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString
+	for _, attributeName := range attributeNames {
+		nameLen := len(attributeName)
+		if nameLen == 0 {
+			return fmt.Errorf("Attribute name is empty")
+		}
+		if nameLen > 32 {
+			return fmt.Errorf("Attribute name exceeds 32 characters [%s]", attributeName)
+		}
+		if !isAlphaNumeric(attributeName) {
+			return fmt.Errorf("Attribute name contains non-alphanumeric characters or spaces [%s]", attributeName)
+		}
+	}
+
+	return nil
+
+}
+
 func main() {
 
 	// input parameters
@@ -106,7 +130,11 @@ func main() {
 		return
 	}
 	attributeNames := headerRecord[1:]
-	// TODO: validate attribute names?
+	err = validateAttributeNames(attributeNames)
+	if err != nil {
+		fmt.Printf("Invalid attribute name: %s\n\n", err)
+		return
+	}
 
 	// Read each row (user identifier + attribute values)
 	userCount := 0

--- a/jcapi-systemusers.go
+++ b/jcapi-systemusers.go
@@ -78,8 +78,8 @@ func (jcuser JCUser) ToString() string {
 	returnVal += fmt.Sprintf("JCUSER: PasswordExpired=[%t] - Active=[%t] - PendingProvisioning=[%t]\n", jcuser.PasswordExpired, jcuser.Activated,
 		jcuser.PendingProvisioning)
 
-	if len(jcuser.Attributes) > 0 {
-		returnVal += fmt.Sprintf("JCUSER: Attributes %s", jcuser.Attributes)
+	for _, attribute := range jcuser.Attributes {
+		returnVal += fmt.Sprintf("\t%s\n", attribute.ToString())
 	}
 
 	for _, tag := range jcuser.Tags {
@@ -87,6 +87,10 @@ func (jcuser JCUser) ToString() string {
 	}
 
 	return returnVal
+}
+
+func (attribute JCUserAttribute) ToString() string {
+	return fmt.Sprintf("attribute [%s: %s]", attribute.Name, attribute.Value)
 }
 
 func setTagIds(user *JCUser) {
@@ -161,12 +165,17 @@ func getJCUserFieldsFromInterface(fields map[string]interface{}, user *JCUser) e
 		}
 	}
 
-	if _, exists := fields["attributes"]; exists {
-		attributes := fields["attributes"].([]interface{})
+	if attrs, exists := fields["attributes"]; exists {
+		attributes := attrs.([]interface{})
 		for _, attributeMapInt := range attributes {
 			attributeMap := attributeMapInt.(map[string]interface{})
-			user.Attributes = append(user.Attributes,
-				JCUserAttribute{Name: attributeMap["name"].(string), Value: attributeMap["value"].(string)})
+			attrName, nameExists := attributeMap["name"]
+			if nameExists {
+				attrValue, valueExists := attributeMap["value"]
+				if valueExists {
+					user.Attributes = append(user.Attributes, JCUserAttribute{Name: attrName.(string), Value: attrValue.(string)})
+				}
+			}
 		}
 	}
 

--- a/jcapi-systemusers.go
+++ b/jcapi-systemusers.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+type JCUserAttribute struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // If you add a field here make sure to add corresponding logic to getJCUserFieldsFromInterface
 type JCUser struct {
 	Id                     string    `json:"_id,omitempty"`
@@ -26,6 +31,8 @@ type JCUser struct {
 	Uid                    string    `json:"unix_uid"`
 	Gid                    string    `json:"unix_guid"`
 	EnableManagedUid       bool      `json:"enable_managed_uid"`
+
+	Attributes []JCUserAttribute `json:"attributes,omitempty"`
 
 	TagIds []string `json:"tags,omitempty"` // the list of tag IDs that this user should be put in
 
@@ -70,6 +77,10 @@ func (jcuser JCUser) ToString() string {
 
 	returnVal += fmt.Sprintf("JCUSER: PasswordExpired=[%t] - Active=[%t] - PendingProvisioning=[%t]\n", jcuser.PasswordExpired, jcuser.Activated,
 		jcuser.PendingProvisioning)
+
+	if len(jcuser.Attributes) > 0 {
+		returnVal += fmt.Sprintf("JCUSER: Attributes %s", jcuser.Attributes)
+	}
 
 	for _, tag := range jcuser.Tags {
 		returnVal += fmt.Sprintf("\t%s\n", tag.ToString())
@@ -149,6 +160,16 @@ func getJCUserFieldsFromInterface(fields map[string]interface{}, user *JCUser) e
 			return err
 		}
 	}
+
+	if _, exists := fields["attributes"]; exists {
+		attributes := fields["attributes"].([]interface{})
+		for _, attributeMapInt := range attributes {
+			attributeMap := attributeMapInt.(map[string]interface{})
+			user.Attributes = append(user.Attributes,
+				JCUserAttribute{Name: attributeMap["name"].(string), Value: attributeMap["value"].(string)})
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Script to allow administrators to bulk add attributes to system users via a CSV file. 

Things of note/discussion:
- Import script calls API PUT directly passing just attributes array (not sure if update on system user would be preferred)
- Attributes are now populated on jcapi.JCUser, not sure if interface handling is optimal
- Tested CSVImporter (add/update users) to ensure existing attributes are not affected on update
