### PR TITLE
Expand Password Expiry helper to encompass MFA state

### DIFF
--- a/examples/PasswordExpiryWatcher/passwordExpiryWatcher.go
+++ b/examples/PasswordExpiryWatcher/passwordExpiryWatcher.go
@@ -19,8 +19,8 @@ func main() {
 	var csvFile string
 
 	// Obtain the input parameters
-	flag.StringVar(&csvFile, "output", "o", "-output=<filename>")
-	flag.StringVar(&apiKey, "key", "k", "-key=<API-key-value>")
+	flag.StringVar(&csvFile, "output", "", "-output=<filename>")
+	flag.StringVar(&apiKey, "key", "", "-key=<API-key-value>")
 	flag.Parse()
 
 	if csvFile == "" || apiKey == "" {

--- a/examples/PasswordExpiryWatcher/passwordExpiryWatcher.go
+++ b/examples/PasswordExpiryWatcher/passwordExpiryWatcher.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/TheJumpCloud/jcapi"
@@ -52,7 +53,7 @@ func main() {
 	defer file.Close()
 	w := csv.NewWriter(file)
 
-	if err := w.Write([]string{"FIRSTNAME", "LASTNAME", "EMAIL", "PASSWORD EXPIRY DATE", "PASSWORD EXPIRED"}); err != nil {
+	if err := w.Write([]string{"FIRSTNAME", "LASTNAME", "EMAIL", "PASSWORD EXPIRY DATE", "PASSWORD EXPIRED", "MFA ENABLED", "MFA VERIFIED"}); err != nil {
 		log.Fatalln("error writing record to csv:", err)
 	}
 
@@ -69,7 +70,7 @@ func main() {
 		} else {
 			passwordExpirationString = record.PasswordExpirationDate.String()
 		}
-		if err := w.Write([]string{record.FirstName, record.LastName, record.Email, passwordExpirationString, expired}); err != nil {
+		if err := w.Write([]string{record.FirstName, record.LastName, record.Email, passwordExpirationString, expired, strconv.FormatBool(record.EnableUserPortalMultifactor), strconv.FormatBool(record.TotpEnabled)}); err != nil {
 			log.Fatalln("error writing record to csv:", err)
 		}
 	}

--- a/jcapi-systemusers.go
+++ b/jcapi-systemusers.go
@@ -9,23 +9,25 @@ import (
 
 // If you add a field here make sure to add corresponding logic to getJCUserFieldsFromInterface
 type JCUser struct {
-	Id                     string    `json:"_id,omitempty"`
-	UserName               string    `json:"username,omitempty"`
-	FirstName              string    `json:"firstname,omitempty"`
-	LastName               string    `json:"lastname,omitempty"`
-	Email                  string    `json:"email"`
-	Password               string    `json:"password,omitempty"`
-	PasswordDate           string    `json:"password_date,omitempty"`
-	Activated              bool      `json:"activated"`
-	ActivationKey          string    `json:"activation_key"`
-	ExpiredWarned          bool      `json:"expired_warned"`
-	PasswordExpired        bool      `json:"password_expired"`
-	PasswordExpirationDate time.Time `json:"password_expiration_date,omitempty"`
-	PendingProvisioning    bool      `json:"pendingProvisioning,omitempty"`
-	Sudo                   bool      `json:"sudo"`
-	Uid                    string    `json:"unix_uid"`
-	Gid                    string    `json:"unix_guid"`
-	EnableManagedUid       bool      `json:"enable_managed_uid"`
+	Id                          string    `json:"_id,omitempty"`
+	UserName                    string    `json:"username,omitempty"`
+	FirstName                   string    `json:"firstname,omitempty"`
+	LastName                    string    `json:"lastname,omitempty"`
+	Email                       string    `json:"email"`
+	Password                    string    `json:"password,omitempty"`
+	PasswordDate                string    `json:"password_date,omitempty"`
+	Activated                   bool      `json:"activated"`
+	ActivationKey               string    `json:"activation_key"`
+	ExpiredWarned               bool      `json:"expired_warned"`
+	PasswordExpired             bool      `json:"password_expired"`
+	PasswordExpirationDate      time.Time `json:"password_expiration_date,omitempty"`
+	PendingProvisioning         bool      `json:"pendingProvisioning,omitempty"`
+	Sudo                        bool      `json:"sudo"`
+	Uid                         string    `json:"unix_uid"`
+	Gid                         string    `json:"unix_guid"`
+	EnableManagedUid            bool      `json:"enable_managed_uid"`
+	EnableUserPortalMultifactor bool      `json:"enable_user_portal_multifactor"`
+	TotpEnabled                 bool      `json:"totp_enabled"`
 
 	TagIds []string `json:"tags,omitempty"` // the list of tag IDs that this user should be put in
 
@@ -148,6 +150,18 @@ func getJCUserFieldsFromInterface(fields map[string]interface{}, user *JCUser) e
 		if err != nil {
 			return err
 		}
+	}
+	if _, exists := fields["enable_user_portal_multifactor"]; exists {
+		if value, err := strconv.ParseBool(fields["enable_user_portal_multifactor"]); err != nil {
+			return err
+		}
+		user.EnableUserPortalMultifactor = value
+	}
+	if _, exists := fields["totp_enabled"]; exists {
+		if value, err := strconv.ParseBool(fields["totp_enabled"]); err != nil {
+			return err
+		}
+		user.TotpEnabled = value
 	}
 	return nil
 }

--- a/jcapi-systemusers.go
+++ b/jcapi-systemusers.go
@@ -152,16 +152,10 @@ func getJCUserFieldsFromInterface(fields map[string]interface{}, user *JCUser) e
 		}
 	}
 	if _, exists := fields["enable_user_portal_multifactor"]; exists {
-		if value, err := strconv.ParseBool(fields["enable_user_portal_multifactor"]); err != nil {
-			return err
-		}
-		user.EnableUserPortalMultifactor = value
+		user.EnableUserPortalMultifactor = fields["enable_user_portal_multifactor"].(bool)
 	}
 	if _, exists := fields["totp_enabled"]; exists {
-		if value, err := strconv.ParseBool(fields["totp_enabled"]); err != nil {
-			return err
-		}
-		user.TotpEnabled = value
+		user.TotpEnabled = fields["totp_enabled"].(bool)
 	}
 	return nil
 }


### PR DESCRIPTION
Adds `MFA ENABLED` and `MFA VERIFIED` columns to the password expiry helper for admins to track who has enabled MFA within their org