### PR TITLE
Update example scripts to work with Groups orgs + fix ExportUsersPerSystemToCSV

### DIFF
--- a/examples/ExportSystemsToCSV/checkOrgType.go
+++ b/examples/ExportSystemsToCSV/checkOrgType.go
@@ -4,17 +4,19 @@ import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 
 // the following constants are used for API v2 calls:
 const (
-	contentType        string = "application/json"
-	accept             string = "application/json"
-	searchLimit        int    = 100
-	searchSkipInterval int    = 100
+	apiKeyEnvVariable  = "JUMPCLOUD_APIKEY"
+	apiKeyHeader       = "x-api-key"
+	contentType        = "application/json"
+	accept             = "application/json"
+	searchLimit        = 100
+	searchSkipInterval = 100
 )
 
 // isGroupsOrg returns true if this org is groups enabled:
 func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
 	// instantiate a new API object for User Groups:
 	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
-	userGroupsAPI.Configuration.APIKey["x-api-key"] = apiKey
+	userGroupsAPI.Configuration.APIKey[apiKeyHeader] = apiKey
 	// in order to check for groups support, we just query for the list of User groups
 	// (we just ask to retrieve 1) and check the response status code:
 	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")

--- a/examples/ExportSystemsToCSV/checkOrgType.go
+++ b/examples/ExportSystemsToCSV/checkOrgType.go
@@ -1,0 +1,41 @@
+package main
+
+import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+
+// the following constants are used for API v2 calls:
+const (
+	contentType        string = "application/json"
+	accept             string = "application/json"
+	searchLimit        int    = 100
+	searchSkipInterval int    = 100
+)
+
+// isGroupsOrg returns true if this org is groups enabled:
+func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
+	// instantiate a new API object for User Groups:
+	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
+	userGroupsAPI.Configuration.APIKey["x-api-key"] = apiKey
+	// in order to check for groups support, we just query for the list of User groups
+	// (we just ask to retrieve 1) and check the response status code:
+	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")
+
+	// check if we're using the API v1:
+	// we need to explicitly check for 404, since GroupsUserList will also return a json
+	// unmarshalling error (err will not be nil) if we're running this endpoint against
+	// a Tags org and we don't want to treat this case as an error:
+	if res.Response != nil && res.Response.StatusCode == 404 {
+		return false, nil
+	}
+
+	// if there was any kind of other error, return that:
+	if err != nil {
+		return false, err
+	}
+
+	// if we're using API v2, we're expecting a 200:
+	if res.Response.StatusCode == 200 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/examples/ExportSystemsToCSV/exportSystemsToCSV.go
+++ b/examples/ExportSystemsToCSV/exportSystemsToCSV.go
@@ -2,36 +2,78 @@ package main
 
 import (
 	"encoding/csv"
+	"flag"
 	"fmt"
-	"github.com/TheJumpCloud/jcapi"
+	"log"
 	"os"
+
+	"github.com/TheJumpCloud/jcapi"
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 )
 
 const (
-	apiUrl string = "https://console.jumpcloud.com/api"
+	apiUrlDefault string = "https://console.jumpcloud.com/api"
 )
 
 func main() {
-	apiKey := os.Getenv("JUMPCLOUD_APIKEY")
+	var apiKey string
+	var apiUrl string
+
+	// Obtain the input parameters: api key and url (if we want to override the default url)
+	flag.StringVar(&apiKey, "key", "", "-key=<API-key-value>")
+	flag.StringVar(&apiUrl, "url", apiUrlDefault, "-url=<jumpcloud-api-url>")
+	flag.Parse()
+
+	// if the api key isn't specified, try to obtain it through environment variable:
 	if apiKey == "" {
-		fmt.Printf("%s: Please run:\n\n\texport JUMPCLOUD_APIKEY=<your-JumpCloud-API-key>\n", os.Args[0])
-		os.Exit(1)
+		apiKey = os.Getenv("JUMPCLOUD_APIKEY")
 	}
 
-	jc := jcapi.NewJCAPI(apiKey, apiUrl)
-
-	// Grab all systems with their tags
-	systems, err := jc.GetSystems(true)
-	if err != nil {
-		fmt.Printf("Could not read systems, err='%s'\n", err)
+	if apiKey == "" {
+		fmt.Println("Usage:")
+		fmt.Println("  -key=\"\": -key=<API-key-value>")
+		fmt.Println("  -url=\"\": -url=<jumpcloud-api-url> (optional)")
+		fmt.Println("You can also set the API key via the JUMPCLOUD_APIKEY environment variable:")
+		fmt.Println("Run: export JUMPCLOUD_APIKEY=<your-JumpCloud-API-key>")
 		return
+	}
+
+	// check if this org is on Groups or Tags:
+	isGroups, err := isGroupsOrg(apiUrl, apiKey)
+	if err != nil {
+		log.Fatalf("Could not determine your org type, err='%s'\n", err)
+	}
+	// if we're on a groups org, instantiate API v2 objects for systems and system groups
+	// which we'll need  to list the parent system groups for a given system:
+	var systemsAPIv2 *jcapiv2.SystemsApi
+	var systemGroupsAPIv2 *jcapiv2.SystemGroupsApi
+	if isGroups {
+		systemsAPIv2 = jcapiv2.NewSystemsApiWithBasePath(apiUrl + "/v2")
+		systemsAPIv2.Configuration.APIKey["x-api-key"] = apiKey
+		systemGroupsAPIv2 = jcapiv2.NewSystemGroupsApiWithBasePath(apiUrl + "/v2")
+		systemGroupsAPIv2.Configuration.APIKey["x-api-key"] = apiKey
+	}
+
+	// instantiate a jcapi v1 object for all v1 endpoints:
+	jcapiv1 := jcapi.NewJCAPI(apiKey, apiUrl)
+
+	// Grab all systems (with their tags for a Tags)
+	systems, err := jcapiv1.GetSystems(!isGroups)
+	if err != nil {
+		log.Fatalf("Could not read systems, err='%s'\n", err)
 	}
 
 	csvWriter := csv.NewWriter(os.Stdout)
 	defer csvWriter.Flush()
 
 	headers := []string{"Id", "DisplayName", "HostName", "Active", "Instance ID", "OS", "OSVersion",
-		"AgentVersion", "CreatedDate", "LastContactDate", "Tags"}
+		"AgentVersion", "CreatedDate", "LastContactDate"}
+
+	if isGroups {
+		headers = append(headers, "SystemGroups")
+	} else {
+		headers = append(headers, "Tags")
+	}
 
 	csvWriter.Write(headers)
 
@@ -40,8 +82,34 @@ func main() {
 			system.AmazonInstanceID, system.Os, system.Version, system.AgentVersion, system.Created,
 			system.LastContact}
 
-		for _, tag := range system.Tags {
-			outLine = append(outLine, tag.Name)
+		if isGroups {
+			// for a Groups org, let's retrieve the system groups this system is a member of:
+			// NOTE: there are more associations for a system in a Groups org we may want to list here as well:
+			// Policies, direct Users associations, etc
+			var graphs []jcapiv2.GraphObjectWithPaths
+			for skip := 0; skip == 0 || len(graphs) == searchLimit; skip += searchSkipInterval {
+				graphs, _, err := systemsAPIv2.GraphSystemMemberOf(system.Id, contentType, accept, int32(searchLimit), int32(skip))
+				if err != nil {
+					fmt.Printf("Could not retrieve parent groups for system %s, err='%s'\n", system.Id, err)
+				} else {
+					// add the retrieved system groups names to the list for the current system:
+					for _, graph := range graphs {
+						// get the details of the current system group:
+						systemGroup, _, err := systemGroupsAPIv2.GroupsSystemGet(graph.Id, contentType, accept)
+						if err != nil {
+							// just log a message and skip the system group if there's an error retrieving details:
+							fmt.Printf("Could not retrieve info for system group ID %s, err='%s'\n", graph.Id, err)
+						} else {
+							outLine = append(outLine, systemGroup.Name)
+						}
+					}
+				}
+			}
+		} else {
+			// for Tags orgs, we've already retrieved the list of tags in GetSystems:
+			for _, tag := range system.Tags {
+				outLine = append(outLine, tag.Name)
+			}
 		}
 
 		csvWriter.Write(outLine)

--- a/examples/ExportSystemsToCSV/exportSystemsToCSV.go
+++ b/examples/ExportSystemsToCSV/exportSystemsToCSV.go
@@ -31,7 +31,7 @@ func getSystemGroupsforSystem(systemsAPIv2 *jcapiv2.SystemsApi, systemGroupsAPIv
 			systemGroup, _, err := systemGroupsAPIv2.GroupsSystemGet(graph.Id, contentType, accept)
 			if err != nil {
 				// just log a message and skip the system group if there's an error retrieving details:
-				fmt.Printf("Could not retrieve info for system group ID %s, err='%s'\n", graph.Id, err)
+				log.Printf("Could not retrieve info for system group ID %s, err='%s'\n", graph.Id, err)
 				continue
 			}
 			systemGroups = append(systemGroups, systemGroup.Name)
@@ -113,7 +113,7 @@ func main() {
 			systemGroups, err := getSystemGroupsforSystem(systemsAPIv2, systemGroupsAPIv2, system.Id)
 			if err != nil {
 				// if we failed to retrieve the system groups for this system, jsut log a msg and skip system groups:
-				fmt.Printf("getSystemGroupsForSystem failed: %s", err)
+				log.Printf("getSystemGroupsForSystem failed: %s", err)
 				// don't call continue here since we still want to print the current system's details...
 			} else {
 				outLine = append(outLine, systemGroups...)

--- a/examples/ExportUsersPerSystemToCSV/checkOrgType.go
+++ b/examples/ExportUsersPerSystemToCSV/checkOrgType.go
@@ -4,17 +4,19 @@ import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 
 // the following constants are used for API v2 calls:
 const (
-	contentType        string = "application/json"
-	accept             string = "application/json"
-	searchLimit        int    = 100
-	searchSkipInterval int    = 100
+	apiKeyEnvVariable  = "JUMPCLOUD_APIKEY"
+	apiKeyHeader       = "x-api-key"
+	contentType        = "application/json"
+	accept             = "application/json"
+	searchLimit        = 100
+	searchSkipInterval = 100
 )
 
 // isGroupsOrg returns true if this org is groups enabled:
 func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
 	// instantiate a new API object for User Groups:
 	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
-	userGroupsAPI.Configuration.APIKey["x-api-key"] = apiKey
+	userGroupsAPI.Configuration.APIKey[apiKeyHeader] = apiKey
 	// in order to check for groups support, we just query for the list of User groups
 	// (we just ask to retrieve 1) and check the response status code:
 	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")

--- a/examples/ExportUsersPerSystemToCSV/checkOrgType.go
+++ b/examples/ExportUsersPerSystemToCSV/checkOrgType.go
@@ -1,0 +1,41 @@
+package main
+
+import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+
+// the following constants are used for API v2 calls:
+const (
+	contentType        string = "application/json"
+	accept             string = "application/json"
+	searchLimit        int    = 100
+	searchSkipInterval int    = 100
+)
+
+// isGroupsOrg returns true if this org is groups enabled:
+func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
+	// instantiate a new API object for User Groups:
+	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
+	userGroupsAPI.Configuration.APIKey["x-api-key"] = apiKey
+	// in order to check for groups support, we just query for the list of User groups
+	// (we just ask to retrieve 1) and check the response status code:
+	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")
+
+	// check if we're using the API v1:
+	// we need to explicitly check for 404, since GroupsUserList will also return a json
+	// unmarshalling error (err will not be nil) if we're running this endpoint against
+	// a Tags org and we don't want to treat this case as an error:
+	if res.Response != nil && res.Response.StatusCode == 404 {
+		return false, nil
+	}
+
+	// if there was any kind of other error, return that:
+	if err != nil {
+		return false, err
+	}
+
+	// if we're using API v2, we're expecting a 200:
+	if res.Response.StatusCode == 200 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/examples/ExportUsersPerSystemToCSV/main.go
+++ b/examples/ExportUsersPerSystemToCSV/main.go
@@ -118,7 +118,7 @@ func main() {
 
 		if err != nil {
 			// if we fail to retrieve users for the current system, log a msg:
-			fmt.Printf("Failed to retrieve system user bindings: err='%s'\n", err)
+			log.Printf("Failed to retrieve system user bindings: err='%s'\n", err)
 			// make sure we still write the system details before skipping:
 			csvWriter.Write(outLine)
 			continue
@@ -128,7 +128,7 @@ func main() {
 		for _, userId := range userIds {
 			user, err := jcapiv1.GetSystemUserById(userId, false)
 			if err != nil {
-				fmt.Printf("Could not retrieve system user for ID '%s', err='%s'\n", userId, err)
+				log.Printf("Could not retrieve system user for ID '%s', err='%s'\n", userId, err)
 			} else {
 				outLine = append(outLine, fmt.Sprintf("%s (%s)", user.UserName, user.Email))
 			}

--- a/examples/ExportUsersPerSystemToCSV/main.go
+++ b/examples/ExportUsersPerSystemToCSV/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	// if the api key isn't specified, try to obtain it through environment variable:
 	if apiKey == "" {
-		apiKey = os.Getenv("JUMPCLOUD_APIKEY")
+		apiKey = os.Getenv(apiKeyEnvVariable)
 	}
 
 	if apiKey == "" {
@@ -51,7 +51,7 @@ func main() {
 	var systemsAPIv2 *jcapiv2.SystemsApi
 	if isGroups {
 		systemsAPIv2 = jcapiv2.NewSystemsApiWithBasePath(apiUrl + "/v2")
-		systemsAPIv2.Configuration.APIKey["x-api-key"] = apiKey
+		systemsAPIv2.Configuration.APIKey[apiKeyHeader] = apiKey
 	}
 
 	csvWriter := csv.NewWriter(os.Stdout)

--- a/examples/ExportUsersToCSV/checkOrgType.go
+++ b/examples/ExportUsersToCSV/checkOrgType.go
@@ -4,17 +4,19 @@ import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 
 // the following constants are used for API v2 calls:
 const (
-	contentType        string = "application/json"
-	accept             string = "application/json"
-	searchLimit        int    = 100
-	searchSkipInterval int    = 100
+	apiKeyHeader       = "x-api-key"
+	apiKeyEnvVariable  = "JUMPCLOUD_APIKEY"
+	contentType        = "application/json"
+	accept             = "application/json"
+	searchLimit        = 100
+	searchSkipInterval = 100
 )
 
 // isGroupsOrg returns true if this org is groups enabled:
 func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
 	// instantiate a new API object for User Groups:
 	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
-	userGroupsAPI.Configuration.APIKey["x-api-key"] = apiKey
+	userGroupsAPI.Configuration.APIKey[apiKeyHeader] = apiKey
 	// in order to check for groups support, we just query for the list of User groups
 	// (we just ask to retrieve 1) and check the response status code:
 	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")

--- a/examples/ExportUsersToCSV/checkOrgType.go
+++ b/examples/ExportUsersToCSV/checkOrgType.go
@@ -1,0 +1,41 @@
+package main
+
+import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+
+// the following constants are used for API v2 calls:
+const (
+	contentType        string = "application/json"
+	accept             string = "application/json"
+	searchLimit        int    = 100
+	searchSkipInterval int    = 100
+)
+
+// isGroupsOrg returns true if this org is groups enabled:
+func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
+	// instantiate a new API object for User Groups:
+	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
+	userGroupsAPI.Configuration.APIKey["x-api-key"] = apiKey
+	// in order to check for groups support, we just query for the list of User groups
+	// (we just ask to retrieve 1) and check the response status code:
+	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")
+
+	// check if we're using the API v1:
+	// we need to explicitly check for 404, since GroupsUserList will also return a json
+	// unmarshalling error (err will not be nil) if we're running this endpoint against
+	// a Tags org and we don't want to treat this case as an error:
+	if res.Response != nil && res.Response.StatusCode == 404 {
+		return false, nil
+	}
+
+	// if there was any kind of other error, return that:
+	if err != nil {
+		return false, err
+	}
+
+	// if we're using API v2, we're expecting a 200:
+	if res.Response.StatusCode == 200 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/examples/ExportUsersToCSV/exportUsersToCSV.go
+++ b/examples/ExportUsersToCSV/exportUsersToCSV.go
@@ -105,7 +105,7 @@ func main() {
 				graphs, _, err := usersAPIv2.GraphUserMemberOf(user.Id, contentType, accept, int32(searchLimit), int32(skip))
 
 				if err != nil {
-					fmt.Printf("Could not read groups for user %s, err='%s'\n", user.Id, err)
+					log.Printf("Could not read groups for user %s, err='%s'\n", user.Id, err)
 					continue
 				}
 				// output the ids for each user group we retrieved:

--- a/examples/ExportUsersToCSV/exportUsersToCSV.go
+++ b/examples/ExportUsersToCSV/exportUsersToCSV.go
@@ -36,7 +36,7 @@ func main() {
 
 	// if the api key isn't specified, try to obtain it through environment variable:
 	if apiKey == "" {
-		apiKey = os.Getenv("JUMPCLOUD_APIKEY")
+		apiKey = os.Getenv(apiKeyEnvVariable)
 	}
 
 	if apiKey == "" {
@@ -57,7 +57,7 @@ func main() {
 	var usersAPIv2 *jcapiv2.UsersApi
 	if isGroups {
 		usersAPIv2 = jcapiv2.NewUsersApiWithBasePath(apiUrl + "/v2")
-		usersAPIv2.Configuration.APIKey["x-api-key"] = apiKey
+		usersAPIv2.Configuration.APIKey[apiKeyHeader] = apiKey
 	}
 
 	jcapiv1 := jcapi.NewJCAPI(apiKey, apiUrl)
@@ -106,11 +106,11 @@ func main() {
 
 				if err != nil {
 					fmt.Printf("Could not read groups for user %s, err='%s'\n", user.Id, err)
-				} else {
-					// output the ids for each user group we retrieved:
-					for _, graph := range graphs {
-						out(graph.Id)
-					}
+					continue
+				}
+				// output the ids for each user group we retrieved:
+				for _, graph := range graphs {
+					out(graph.Id)
 				}
 			}
 		} else {

--- a/examples/ExportUsersToCSV/exportUsersToCSV.go
+++ b/examples/ExportUsersToCSV/exportUsersToCSV.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"github.com/TheJumpCloud/jcapi"
+	"log"
 	"os"
+
+	"github.com/TheJumpCloud/jcapi"
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 )
 
 const (
-	apiUrl string = "https://console.jumpcloud.com/api"
+	apiUrlDefault string = "https://console.jumpcloud.com/api"
 )
 
 func outFirst(data string) {
@@ -23,19 +27,45 @@ func endLine() {
 }
 
 func main() {
-	apiKey := os.Getenv("JUMPCLOUD_APIKEY")
+	var apiKey string
+	var apiUrl string
+	// Obtain the input parameters
+	flag.StringVar(&apiKey, "key", "", "-key=<API-key-value>")
+	flag.StringVar(&apiUrl, "url", apiUrlDefault, "-url=<jumpcloud-api-url>")
+	flag.Parse()
+
+	// if the api key isn't specified, try to obtain it through environment variable:
 	if apiKey == "" {
-		fmt.Printf("%s: Please run: export JUMPCLOUD_APIKEY=<your-JumpCloud-API-key>\n")
-		os.Exit(1)
+		apiKey = os.Getenv("JUMPCLOUD_APIKEY")
 	}
 
-	jc := jcapi.NewJCAPI(apiKey, apiUrl)
-
-	// Grab all system users with their tags
-	userList, err := jc.GetSystemUsers(true)
-	if err != nil {
-		fmt.Printf("Could not read system users, err='%s'\n", err)
+	if apiKey == "" {
+		fmt.Println("Usage:")
+		fmt.Println("  -key=\"\": -key=<API-key-value>")
+		fmt.Println("  -url=\"\": -url=<jumpcloud-api-url> (optional)")
+		fmt.Println("You can also set the API key via the JUMPCLOUD_APIKEY environment variable:")
+		fmt.Println("Run: export JUMPCLOUD_APIKEY=<your-JumpCloud-API-key>")
 		return
+	}
+
+	// check if the org is on tags or groups:
+	isGroups, err := isGroupsOrg(apiUrl, apiKey)
+	if err != nil {
+		log.Fatalf("Could not determine your org type, err='%s'\n", err)
+	}
+
+	var usersAPIv2 *jcapiv2.UsersApi
+	if isGroups {
+		usersAPIv2 = jcapiv2.NewUsersApiWithBasePath(apiUrl + "/v2")
+		usersAPIv2.Configuration.APIKey["x-api-key"] = apiKey
+	}
+
+	jcapiv1 := jcapi.NewJCAPI(apiKey, apiUrl)
+
+	// Grab all system users (with their tags if this is a Tags org):
+	userList, err := jcapiv1.GetSystemUsers(!isGroups)
+	if err != nil {
+		log.Fatalf("Could not read system users, err='%s'\n", err)
 	}
 
 	outFirst("Username")
@@ -47,7 +77,11 @@ func main() {
 	out("Activated")
 	out("PasswordExpired")
 	out("Sudo")
-	out("Tags")
+	if isGroups {
+		out("User Groups")
+	} else {
+		out("Tags")
+	}
 	endLine()
 
 	for _, user := range userList {
@@ -61,8 +95,29 @@ func main() {
 		out(fmt.Sprintf("%t", user.PasswordExpired))
 		out(fmt.Sprintf("%t", user.Sudo))
 
-		for _, tag := range user.Tags {
-			out(tag.Name)
+		if isGroups {
+			// For now, just list the User Groups this user is a member of.
+			// NOTE: there are many more associations for a user in a Groups org we may want to list here as well:
+			// Applications, Directories, GSuite, LDAP, O365, Systems, Radius Servers
+
+			var graphs []jcapiv2.GraphObjectWithPaths
+			for skip := 0; skip == 0 || len(graphs) == searchLimit; skip += searchSkipInterval {
+				graphs, _, err := usersAPIv2.GraphUserMemberOf(user.Id, contentType, accept, int32(searchLimit), int32(skip))
+
+				if err != nil {
+					fmt.Printf("Could not read groups for user %s, err='%s'\n", user.Id, err)
+				} else {
+					// output the ids for each user group we retrieved:
+					for _, graph := range graphs {
+						out(graph.Id)
+					}
+				}
+			}
+		} else {
+			// this is a Tags org, just list the Tags we've already retrieved:
+			for _, tag := range user.Tags {
+				out(tag.Name)
+			}
 		}
 
 		endLine()

--- a/jcapi-systems.go
+++ b/jcapi-systems.go
@@ -278,6 +278,9 @@ func (jc JCAPI) GetSystemUserBindingsById(systemId string) (systemUserBindings [
 		var binding SystemUserBinding
 		// unmarshall the current raw json into a system user binding:
 		err = json.Unmarshal(*userBindingMap[userId], &binding)
+		if err != nil {
+			return systemUserBindings, fmt.Errorf("ERROR: Could not unmarshal buffer '%s', err='%s'", *userBindingMap[userId], err.Error())
+		}
 		// set the user id (obtained from the current key)
 		// since it isn't populated in the json response:
 		binding.UserId = userId

--- a/jcapi-systems.go
+++ b/jcapi-systems.go
@@ -46,6 +46,13 @@ type JCSystem struct {
 	Tags    []JCTag
 }
 
+// this struct describes a system user binding :
+type SystemUserBinding struct {
+	UserId   string   `json:"id,omitempty"`
+	Username string   `json:"username,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+}
+
 type JCSSHDParam struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
@@ -244,4 +251,39 @@ func (jc JCAPI) DeleteSystem(system JCSystem) JCError {
 	}
 
 	return nil
+}
+
+// GetSystemUserBindingsById returns all the user bindings for the given system Id:
+// this includes the direct system-user bindings as well as the bindings made via tags
+func (jc JCAPI) GetSystemUserBindingsById(systemId string) (systemUserBindings []SystemUserBinding, err JCError) {
+	url := fmt.Sprintf("%s/%s/systemusers", SYSTEMS_PATH, systemId)
+
+	buffer, err := jc.DoBytes(MapJCOpToHTTP(Read), url, []byte{})
+	if err != nil {
+		return systemUserBindings, fmt.Errorf("ERROR: Could not get system user bindings for system ID '%s', err='%s'", systemId, err.Error())
+	}
+
+	// The response from the /systems/<system_id>/users endpoint is a map of system-user bindings
+	// keyed on the user ID, so we can't unmarshall it in one operation:
+	// first parse the response into a map of generic json objects:
+	var userBindingMap map[string]*json.RawMessage
+	err = json.Unmarshal(buffer, &userBindingMap)
+
+	if err != nil {
+		return systemUserBindings, fmt.Errorf("ERROR: Could not unmarshal buffer '%s', err='%s'", buffer, err.Error())
+	}
+
+	// iterate over the map of user bindings:
+	for userId, _ := range userBindingMap {
+		var binding SystemUserBinding
+		// unmarshall the current raw json into a system user binding:
+		err = json.Unmarshal(*userBindingMap[userId], &binding)
+		// set the user id (obtained from the current key)
+		// since it isn't populated in the json response:
+		binding.UserId = userId
+		// append the current user binding to the array:
+		systemUserBindings = append(systemUserBindings, binding)
+	}
+
+	return
 }


### PR DESCRIPTION
Updated some of the scripts that require v2 calls to work with Groups orgs (the others don't need to be modified to work with a Groups org):
- ExportUsersToCSV: modified to output the User Groups a user is a member of
- ExportSystemsToCSV: modified to output the System Groups a system is a member of
- ExportUsersPerSystemToCSV: fixed script to use direct system/user binding instead of relying on tags binding. Also ported script to work with Groups org using /v2/systems/<system_id>/users endpoint. This fixes https://github.com/TheJumpCloud/jumpcloud-issues/issues/647 and https://github.com/TheJumpCloud/jumpcloud-issues/issues/690

Each updated script comes with a helper checkOrgType.go which allows us to tell whether an org uses Tags or Groups. Since these scripts are standalone example scripts, I thought it was ok to just have copies of that same file for each script that uses the helper.

I started working on a groups version of the BackupRestoreTags script but realized that backing up a Group's info requires backing up a lot more than just Users or Systems associations.
It requires backing up /restoring all the groups associations such as : Applications, Directories, GSuite, LDAP, O365, Systems, Radius Servers, Policies etc...
After talking to Rob and Cody, it doesn't even seem like this script is used much, if at all. So we may want to wait for specific customers' requests before coming up with a new Groups version for it.

Note that I'm generating a PR against the jcapi repo, for ease of reviewing the diff, but I will most likely move the scripts to the support repo once they are reviewed.