### PR TITLE
Update example scripts to use new jcapiv2 format

### DIFF
--- a/examples/ExportSystemsToCSV/checkOrgType.go
+++ b/examples/ExportSystemsToCSV/checkOrgType.go
@@ -1,11 +1,14 @@
 package main
 
-import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+import (
+	"context"
+
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+)
 
 // the following constants are used for API v2 calls:
 const (
 	apiKeyEnvVariable  = "JUMPCLOUD_APIKEY"
-	apiKeyHeader       = "x-api-key"
 	contentType        = "application/json"
 	accept             = "application/json"
 	searchLimit        = 100
@@ -14,18 +17,28 @@ const (
 
 // isGroupsOrg returns true if this org is groups enabled:
 func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
-	// instantiate a new API object for User Groups:
-	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
-	userGroupsAPI.Configuration.APIKey[apiKeyHeader] = apiKey
+	// instantiate a new API client object:
+	client := jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
+	client.ChangeBasePath(urlBase + "/v2")
+
+	// set up the API key via context:
+	auth := context.WithValue(context.TODO(), jcapiv2.ContextAPIKey, jcapiv2.APIKey{
+		Key: apiKey,
+	})
+
+	// set up optional parameters:
+	optionals := map[string]interface{}{
+		"limit": int32(1), // limit the query to return 1 item
+	}
 	// in order to check for groups support, we just query for the list of User groups
 	// (we just ask to retrieve 1) and check the response status code:
-	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")
+	_, res, err := client.UserGroupsApi.GroupsUserList(auth, contentType, accept, optionals)
 
 	// check if we're using the API v1:
 	// we need to explicitly check for 404, since GroupsUserList will also return a json
 	// unmarshalling error (err will not be nil) if we're running this endpoint against
 	// a Tags org and we don't want to treat this case as an error:
-	if res.Response != nil && res.Response.StatusCode == 404 {
+	if res != nil && res.StatusCode == 404 {
 		return false, nil
 	}
 
@@ -35,7 +48,7 @@ func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
 	}
 
 	// if we're using API v2, we're expecting a 200:
-	if res.Response.StatusCode == 200 {
+	if res.StatusCode == 200 {
 		return true, nil
 	}
 

--- a/examples/ExportUsersPerSystemToCSV/checkOrgType.go
+++ b/examples/ExportUsersPerSystemToCSV/checkOrgType.go
@@ -1,11 +1,14 @@
 package main
 
-import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+import (
+	"context"
+
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+)
 
 // the following constants are used for API v2 calls:
 const (
 	apiKeyEnvVariable  = "JUMPCLOUD_APIKEY"
-	apiKeyHeader       = "x-api-key"
 	contentType        = "application/json"
 	accept             = "application/json"
 	searchLimit        = 100
@@ -14,18 +17,28 @@ const (
 
 // isGroupsOrg returns true if this org is groups enabled:
 func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
-	// instantiate a new API object for User Groups:
-	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
-	userGroupsAPI.Configuration.APIKey[apiKeyHeader] = apiKey
+	// instantiate a new API client object:
+	client := jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
+	client.ChangeBasePath(urlBase + "/v2")
+
+	// set up the API key via context:
+	auth := context.WithValue(context.TODO(), jcapiv2.ContextAPIKey, jcapiv2.APIKey{
+		Key: apiKey,
+	})
+
+	// set up optional parameters:
+	optionals := map[string]interface{}{
+		"limit": int32(1), // limit the query to return 1 item
+	}
 	// in order to check for groups support, we just query for the list of User groups
 	// (we just ask to retrieve 1) and check the response status code:
-	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")
+	_, res, err := client.UserGroupsApi.GroupsUserList(auth, contentType, accept, optionals)
 
 	// check if we're using the API v1:
 	// we need to explicitly check for 404, since GroupsUserList will also return a json
 	// unmarshalling error (err will not be nil) if we're running this endpoint against
 	// a Tags org and we don't want to treat this case as an error:
-	if res.Response != nil && res.Response.StatusCode == 404 {
+	if res != nil && res.StatusCode == 404 {
 		return false, nil
 	}
 
@@ -35,7 +48,7 @@ func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
 	}
 
 	// if we're using API v2, we're expecting a 200:
-	if res.Response.StatusCode == 200 {
+	if res.StatusCode == 200 {
 		return true, nil
 	}
 

--- a/examples/ExportUsersToCSV/checkOrgType.go
+++ b/examples/ExportUsersToCSV/checkOrgType.go
@@ -1,10 +1,13 @@
 package main
 
-import jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+import (
+	"context"
+
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+)
 
 // the following constants are used for API v2 calls:
 const (
-	apiKeyHeader       = "x-api-key"
 	apiKeyEnvVariable  = "JUMPCLOUD_APIKEY"
 	contentType        = "application/json"
 	accept             = "application/json"
@@ -14,18 +17,28 @@ const (
 
 // isGroupsOrg returns true if this org is groups enabled:
 func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
-	// instantiate a new API object for User Groups:
-	userGroupsAPI := jcapiv2.NewUserGroupsApiWithBasePath(urlBase + "/v2")
-	userGroupsAPI.Configuration.APIKey[apiKeyHeader] = apiKey
+	// instantiate a new API client object:
+	client := jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
+	client.ChangeBasePath(urlBase + "/v2")
+
+	// set up the API key via context:
+	auth := context.WithValue(context.TODO(), jcapiv2.ContextAPIKey, jcapiv2.APIKey{
+		Key: apiKey,
+	})
+
+	// set up optional parameters:
+	optionals := map[string]interface{}{
+		"limit": int32(1), // limit the query to return 1 item
+	}
 	// in order to check for groups support, we just query for the list of User groups
 	// (we just ask to retrieve 1) and check the response status code:
-	_, res, err := userGroupsAPI.GroupsUserList(contentType, accept, "", "", 1, 0, "")
+	_, res, err := client.UserGroupsApi.GroupsUserList(auth, contentType, accept, optionals)
 
 	// check if we're using the API v1:
 	// we need to explicitly check for 404, since GroupsUserList will also return a json
 	// unmarshalling error (err will not be nil) if we're running this endpoint against
 	// a Tags org and we don't want to treat this case as an error:
-	if res.Response != nil && res.Response.StatusCode == 404 {
+	if res != nil && res.StatusCode == 404 {
 		return false, nil
 	}
 
@@ -35,7 +48,7 @@ func isGroupsOrg(urlBase string, apiKey string) (bool, error) {
 	}
 
 	// if we're using API v2, we're expecting a 200:
-	if res.Response.StatusCode == 200 {
+	if res.StatusCode == 200 {
 		return true, nil
 	}
 

--- a/examples/ExportUsersToCSV/exportUsersToCSV.go
+++ b/examples/ExportUsersToCSV/exportUsersToCSV.go
@@ -55,10 +55,10 @@ func main() {
 		log.Fatalf("Could not determine your org type, err='%s'\n", err)
 	}
 
+	// if we're on a groups org, instantiate API client v2:
 	var apiClientV2 *jcapiv2.APIClient
 	var auth context.Context
 	if isGroups {
-		// instantiate API client v2:
 		apiClientV2 = jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
 		apiClientV2.ChangeBasePath(apiUrl + "/v2")
 		// set up the API key via context:

--- a/examples/ExportUsersToCSV/exportUsersToCSV.go
+++ b/examples/ExportUsersToCSV/exportUsersToCSV.go
@@ -55,22 +55,23 @@ func main() {
 		log.Fatalf("Could not determine your org type, err='%s'\n", err)
 	}
 
-	var clientV2 *jcapiv2.APIClient
+	var apiClientV2 *jcapiv2.APIClient
 	var auth context.Context
 	if isGroups {
 		// instantiate API client v2:
-		clientV2 = jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
-		clientV2.ChangeBasePath(apiUrl + "/v2")
+		apiClientV2 = jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
+		apiClientV2.ChangeBasePath(apiUrl + "/v2")
 		// set up the API key via context:
 		auth = context.WithValue(context.TODO(), jcapiv2.ContextAPIKey, jcapiv2.APIKey{
 			Key: apiKey,
 		})
 	}
 
-	jcapiv1 := jcapi.NewJCAPI(apiKey, apiUrl)
+	// instantiate the API client v1:
+	apiClientV1 := jcapi.NewJCAPI(apiKey, apiUrl)
 
 	// Grab all system users (with their tags if this is a Tags org):
-	userList, err := jcapiv1.GetSystemUsers(!isGroups)
+	userList, err := apiClientV1.GetSystemUsers(!isGroups)
 	if err != nil {
 		log.Fatalf("Could not read system users, err='%s'\n", err)
 	}
@@ -114,7 +115,7 @@ func main() {
 					"limit": int32(searchLimit),
 					"skip":  int32(skip),
 				}
-				graphs, _, err := clientV2.UsersApi.GraphUserMemberOf(auth, user.Id, contentType, accept, optionals)
+				graphs, _, err := apiClientV2.UsersApi.GraphUserMemberOf(auth, user.Id, contentType, accept, optionals)
 
 				if err != nil {
 					log.Printf("Could not read groups for user %s, err='%s'\n", user.Id, err)

--- a/examples/ExportUsersToCSV/exportUsersToCSV.go
+++ b/examples/ExportUsersToCSV/exportUsersToCSV.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -54,10 +55,16 @@ func main() {
 		log.Fatalf("Could not determine your org type, err='%s'\n", err)
 	}
 
-	var usersAPIv2 *jcapiv2.UsersApi
+	var clientV2 *jcapiv2.APIClient
+	var auth context.Context
 	if isGroups {
-		usersAPIv2 = jcapiv2.NewUsersApiWithBasePath(apiUrl + "/v2")
-		usersAPIv2.Configuration.APIKey[apiKeyHeader] = apiKey
+		// instantiate API client v2:
+		clientV2 = jcapiv2.NewAPIClient(jcapiv2.NewConfiguration())
+		clientV2.ChangeBasePath(apiUrl + "/v2")
+		// set up the API key via context:
+		auth = context.WithValue(context.TODO(), jcapiv2.ContextAPIKey, jcapiv2.APIKey{
+			Key: apiKey,
+		})
 	}
 
 	jcapiv1 := jcapi.NewJCAPI(apiKey, apiUrl)
@@ -102,7 +109,12 @@ func main() {
 
 			var graphs []jcapiv2.GraphObjectWithPaths
 			for skip := 0; skip == 0 || len(graphs) == searchLimit; skip += searchSkipInterval {
-				graphs, _, err := usersAPIv2.GraphUserMemberOf(user.Id, contentType, accept, int32(searchLimit), int32(skip))
+				// set up optional parameters:
+				optionals := map[string]interface{}{
+					"limit": int32(searchLimit),
+					"skip":  int32(skip),
+				}
+				graphs, _, err := clientV2.UsersApi.GraphUserMemberOf(auth, user.Id, contentType, accept, optionals)
 
 				if err != nil {
 					log.Printf("Could not read groups for user %s, err='%s'\n", user.Id, err)


### PR DESCRIPTION
I've recently made changes to jcapiv2 which is now generated with swagger-codegen 2.3.0. That involves a few format changes for setting up the client API, API key, and methods parameters.
This is just an update of the examples scripts that use jcapiv2 in order to use the new format.