### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 jcapi
 =====
 
-This Repository only supports JumpCloud's V1 API endpoints. For V2 Support please refer to [jcapi-go](https://github.com/TheJumpCloud/jcapi-go).
-
-Please note that this V1 Go SDK is currently out of date with Jumpcloud's v1 API functionality. This is due to a bug in Swagger Code Gen and how we auto-deploy SDK updates. If you need an updated version of the V1 GO SDK please file an issue in this repository and we can evaluate the request on a per need basis.  If you need to only use our V2 set of endpoints, you can refer to our V2 SDK for Go that supports those endpoints as those are currently up to date with V2 API functionality.  
-
+This older Go Repository only supports JumpCloud's V1 API endpoints as in not currently up to date with our API functionality. 
+For current V1 & V2 API Support please refer to [jcapi-go](https://github.com/TheJumpCloud/jcapi-go)
+ 
 The scripts under the 'examples' folder in this repo are now deprecated.
 Please refer to [the support repository](https://github.com/TheJumpCloud/support/tree/master/api-utils/JumpCloud_API_Go_Examples) for the maintained examples scripts.
 
@@ -13,11 +12,7 @@ Binaries for these scripts can be found in the [releases](https://github.com/The
 *JumpCloud's Go (golang) REST API SDK (BETA)*
 Copyright (C) 2015 JumpCloud
 
-This JumpCloud SDK is in beta form. The only available documentation comes in the form of the included examples and from jcapi_test.go (best stuff is in there).
-
-Two things to keep in mind as you use this:
- * Use it at your own risk.
- * Please know that this SDK will change over time.
+This JumpCloud SDK is in beta form. The only available documentation comes in the form of the included examples and from jcapi_test.go 
 
 This API exposes several JumpCloud REST APIs:
  * System Users - (see https://github.com/TheJumpCloud/JumpCloudAPI#system-users)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jcapi
 =====
 
-This older Go Repository only supports JumpCloud's V1 API endpoints as in not currently up to date with our API functionality. 
+This older Go Repository only supports JumpCloud's V1 API endpoints and is not currently up to date with our API functionality. 
 For current V1 & V2 API Support please refer to [jcapi-go](https://github.com/TheJumpCloud/jcapi-go)
  
 The scripts under the 'examples' folder in this repo are now deprecated.


### PR DESCRIPTION
clarified that this is out of date with our current API functionality and most users should use our new jcapi-go library.