### PR TITLE
Multi-tenant admin, runs scripts in api-utils/examples in support repo DE-101

### DIFF
--- a/examples/ExportSystemsToCSV/exportSystemsToCSV.go
+++ b/examples/ExportSystemsToCSV/exportSystemsToCSV.go
@@ -34,7 +34,7 @@ func getSystemGroupsforSystem(apiClientV2 *jcapiv2.APIClient, auth context.Conte
 		// add the retrieved system groups names to the list for the current system:
 		for _, graph := range graphs {
 			// get the details of the current system group:
-			systemGroup, _, err := apiClientV2.SystemGroupsApi.GroupsSystemGet(auth, graph.Id, contentType, accept)
+			systemGroup, _, err := apiClientV2.SystemGroupsApi.GroupsSystemGet(auth, graph.Id, contentType, accept, nil)
 			if err != nil {
 				// just log a message and skip the system group if there's an error retrieving details:
 				log.Printf("Could not retrieve info for system group ID %s, err='%s'\n", graph.Id, err)

--- a/jcapi-systemusers.go
+++ b/jcapi-systemusers.go
@@ -166,11 +166,11 @@ func getJCUserFieldsFromInterface(fields map[string]interface{}, user *JCUser) e
 			return err
 		}
 	}
-  
+
 	if _, exists := fields["enable_user_portal_multifactor"]; exists {
 		user.EnableUserPortalMultifactor = fields["enable_user_portal_multifactor"].(bool)
 	}
-  
+
 	if _, exists := fields["totp_enabled"]; exists {
 		user.TotpEnabled = fields["totp_enabled"].(bool)
 	}
@@ -260,7 +260,7 @@ func (jc JCAPI) GetSystemUserById(userId string, withTags bool) (user JCUser, er
 			// a compiler bug here in that it thinks a := of err is shadowed here,
 			// even though tags should be the only variable declared with the :=
 			tags, err2 := jc.GetAllTags()
-			if err != nil {
+			if err2 != nil {
 				err = fmt.Errorf("ERROR: Could not get tags, err='%s'", err2)
 				return user, err
 			}
@@ -280,7 +280,7 @@ func (jc JCAPI) GetSystemUsers(withTags bool) (userList []JCUser, err JCError) {
 		url := fmt.Sprintf("/systemusers?sort=username&skip=%d&limit=%d", skip, searchLimit)
 
 		jcUserRec, err2 := jc.Get(url)
-		if err != nil {
+		if err2 != nil {
 			return nil, fmt.Errorf("ERROR: Post to JumpCloud failed, err='%s'", err2)
 		}
 
@@ -306,7 +306,7 @@ func (jc JCAPI) GetSystemUsers(withTags bool) (userList []JCUser, err JCError) {
 				// See above about the compiler error that requires me to use err2 instead of err below...
 				//
 				detailedUser, err2 := jc.GetSystemUserById(returnVal[i].Id, false)
-				if err != nil {
+				if err2 != nil {
 					err = fmt.Errorf("ERROR: Could not get details for user ID '%s', err='%s'", returnVal[i].Id, err2)
 					return
 				}

--- a/jcapi.go
+++ b/jcapi.go
@@ -31,6 +31,7 @@ const (
 type JCAPI struct {
 	ApiKey  string
 	UrlBase string
+	OrgId   string
 }
 
 const (
@@ -60,6 +61,7 @@ func NewJCAPI(apiKey string, urlBase string) JCAPI {
 	return JCAPI{
 		ApiKey:  apiKey,
 		UrlBase: urlBase,
+		OrgId: "",
 	}
 }
 
@@ -128,6 +130,9 @@ func (jc JCAPI) setHeader(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("x-api-key", jc.ApiKey)
+	if jc.OrgId != "" {
+		req.Header.Set("x-org-id", jc.OrgId)
+	}
 }
 
 func (jc JCAPI) Post(url string, data []byte) (interface{}, JCError) {


### PR DESCRIPTION
Ability to run scripts in the support repo requires these additive changes to the API.

Two changes are the result of existing errors in the source base.

This change is required by https://github.com/TheJumpCloud/support/pull/43